### PR TITLE
Add Walker theme integration

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -5,10 +5,17 @@
 # omarchy_bin_dir = "~/.local/share/omarchy/bin"
 # waybar_dir = "~/.config/waybar"
 # waybar_themes_dir = "~/.config/waybar/themes"
+# walker_dir = "~/.config/walker"
+# walker_themes_dir = "~/.config/walker/themes"
 # starship_config = "~/.config/starship.toml"
 # starship_themes_dir = "~/.config/starship-themes"
 
 [waybar]
+# apply_mode = "symlink" # symlink|copy
+# default_mode = "auto" # auto|named|"" (empty = none)
+# default_name = ""
+
+[walker]
 # apply_mode = "symlink" # symlink|copy
 # default_mode = "auto" # auto|named|"" (empty = none)
 # default_name = ""

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -24,6 +24,7 @@ pub enum Command {
   Remove(RemoveArgs),
   Preset(PresetArgs),
   Waybar(WaybarArgs),
+  Walker(WalkerArgs),
   Starship(StarshipArgs),
 }
 
@@ -102,6 +103,13 @@ pub struct PresetRemoveArgs {
 
 #[derive(Parser, Debug)]
 pub struct WaybarArgs {
+  pub mode: String,
+  #[arg(short = 'q', long = "quiet")]
+  pub quiet: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct WalkerArgs {
   pub mode: String,
   #[arg(short = 'q', long = "quiet")]
   pub quiet: bool,

--- a/rust/src/git_ops.rs
+++ b/rust/src/git_ops.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use crate::config::ResolvedConfig;
 use crate::omarchy;
 use crate::paths::normalize_theme_name;
-use crate::theme_ops::{self, CommandContext};
+use crate::theme_ops::{self, CommandContext, walker_from_defaults};
 
 pub struct GitContext<'a> {
   pub config: &'a ResolvedConfig,
@@ -122,6 +122,7 @@ fn resolve_entry(path: PathBuf) -> PathBuf {
 
 fn default_command_context<'a>(config: &'a ResolvedConfig) -> CommandContext<'a> {
   let (waybar_mode, waybar_name) = theme_ops::waybar_from_defaults(config);
+  let (walker_mode, walker_name) = walker_from_defaults(config);
   let starship_mode = theme_ops::starship_from_defaults(config);
   let skip_apps = std::env::var("THEME_MANAGER_SKIP_APPS").is_ok();
   let skip_hook = std::env::var("THEME_MANAGER_SKIP_HOOK").is_ok();
@@ -132,6 +133,8 @@ fn default_command_context<'a>(config: &'a ResolvedConfig) -> CommandContext<'a>
     skip_hook,
     waybar_mode,
     waybar_name,
+    walker_mode,
+    walker_name,
     starship_mode,
     debug_awww: false,
   }

--- a/rust/src/preview.rs
+++ b/rust/src/preview.rs
@@ -12,6 +12,10 @@ pub fn find_waybar_preview(waybar_dir: &Path) -> Option<PathBuf> {
   find_first_png(waybar_dir)
 }
 
+pub fn find_walker_preview(walker_dir: &Path) -> Option<PathBuf> {
+  find_first_png(walker_dir)
+}
+
 fn find_named_file(dir: &Path, name: &str) -> Option<PathBuf> {
   if !dir.is_dir() {
     return None;

--- a/rust/src/theme_ops.rs
+++ b/rust/src/theme_ops.rs
@@ -12,10 +12,18 @@ use crate::paths::{
   title_case_theme,
 };
 use crate::starship;
+use crate::walker;
 use crate::waybar;
 
 #[derive(Debug, Clone)]
 pub enum WaybarMode {
+  None,
+  Auto,
+  Named,
+}
+
+#[derive(Debug, Clone)]
+pub enum WalkerMode {
   None,
   Auto,
   Named,
@@ -36,6 +44,8 @@ pub struct CommandContext<'a> {
   pub skip_hook: bool,
   pub waybar_mode: WaybarMode,
   pub waybar_name: Option<String>,
+  pub walker_mode: WalkerMode,
+  pub walker_name: Option<String>,
   pub starship_mode: StarshipMode,
   pub debug_awww: bool,
 }
@@ -45,6 +55,14 @@ pub fn waybar_from_defaults(config: &ResolvedConfig) -> (WaybarMode, Option<Stri
     Some("auto") => (WaybarMode::Auto, None),
     Some("named") => (WaybarMode::Named, config.default_waybar_name.clone()),
     _ => (WaybarMode::None, None),
+  }
+}
+
+pub fn walker_from_defaults(config: &ResolvedConfig) -> (WalkerMode, Option<String>) {
+  match config.default_walker_mode.as_deref() {
+    Some("auto") => (WalkerMode::Auto, None),
+    Some("named") => (WalkerMode::Named, config.default_walker_name.clone()),
+    _ => (WalkerMode::None, None),
   }
 }
 
@@ -110,6 +128,7 @@ pub fn cmd_set(ctx: &CommandContext<'_>, theme_name: &str) -> Result<()> {
   let mut waybar_restart = None;
   if !ctx.skip_apps {
     waybar_restart = waybar::prepare_waybar(ctx, &theme_source)?;
+    walker::prepare_walker(ctx, &theme_source)?;
     starship::apply_starship(ctx, &theme_source)?;
   }
 
@@ -173,6 +192,8 @@ pub fn cmd_bg_next(config: &ResolvedConfig, debug_awww: bool) -> Result<()> {
     skip_hook: false,
     waybar_mode: WaybarMode::None,
     waybar_name: None,
+    walker_mode: WalkerMode::None,
+    walker_name: None,
     starship_mode: StarshipMode::None,
     debug_awww,
   };

--- a/rust/src/walker.rs
+++ b/rust/src/walker.rs
@@ -1,0 +1,232 @@
+use anyhow::Result;
+use std::fs;
+use std::path::Path;
+
+use crate::theme_ops::{CommandContext, WalkerMode};
+
+const WALKER_LINKS_FILE: &str = ".theme-manager-walker-links";
+
+pub fn prepare_walker(ctx: &CommandContext<'_>, theme_dir: &Path) -> Result<()> {
+  let (walker_theme_dir, theme_name) = match ctx.walker_mode {
+    WalkerMode::None => return Ok(()),
+    WalkerMode::Auto => {
+      let dir = theme_dir.join("walker-theme");
+      (dir, None)
+    }
+    WalkerMode::Named => match &ctx.walker_name {
+      Some(name) => {
+        let dir = ctx.config.walker_themes_dir.join(name);
+        (dir, Some(name.clone()))
+      }
+      None => return Ok(()),
+    },
+  };
+
+  if !walker_theme_dir.is_dir() {
+    if !ctx.quiet {
+      eprintln!(
+        "theme-manager: walker theme directory not found: {}",
+        walker_theme_dir.to_string_lossy()
+      );
+    }
+    return Ok(());
+  }
+
+  // Walker themes require style.css, layout.xml is optional
+  let style_path = walker_theme_dir.join("style.css");
+  if !style_path.is_file() {
+    if !ctx.quiet {
+      eprintln!(
+        "theme-manager: walker theme missing style.css in {}",
+        walker_theme_dir.to_string_lossy()
+      );
+    }
+    return Ok(());
+  }
+
+  // For named themes that exist in walker_themes_dir, just update the config
+  if let Some(name) = theme_name {
+    return update_walker_config(ctx, &name);
+  }
+
+  // For auto mode (theme-bundled), we need to copy/link the theme files
+  cleanup_walker_links(&ctx.config.walker_dir, ctx.quiet)?;
+
+  let layout_path = walker_theme_dir.join("layout.xml");
+  let apply_mode = ctx.config.walker_apply_mode.as_str();
+  if apply_mode == "copy" {
+    return apply_copy(ctx, &walker_theme_dir, &style_path, &layout_path);
+  }
+
+  apply_symlink(ctx, &walker_theme_dir, &style_path, &layout_path)
+}
+
+fn update_walker_config(ctx: &CommandContext<'_>, theme_name: &str) -> Result<()> {
+  let config_path = ctx.config.walker_dir.join("config.toml");
+
+  if !config_path.is_file() {
+    if !ctx.quiet {
+      eprintln!("theme-manager: walker config not found at {}", config_path.to_string_lossy());
+    }
+    return Ok(());
+  }
+
+  let content = fs::read_to_string(&config_path)?;
+  let mut new_lines = Vec::new();
+  let mut found_theme = false;
+
+  for line in content.lines() {
+    if line.trim_start().starts_with("theme") && line.contains('=') {
+      new_lines.push(format!("theme = \"{}\"", theme_name));
+      found_theme = true;
+    } else {
+      new_lines.push(line.to_string());
+    }
+  }
+
+  if !found_theme {
+    // Insert theme setting near the top (after any initial comments)
+    let insert_pos = new_lines.iter().position(|l| !l.trim().starts_with('#') && !l.trim().is_empty()).unwrap_or(0);
+    new_lines.insert(insert_pos, format!("theme = \"{}\"", theme_name));
+  }
+
+  if !ctx.quiet {
+    println!("theme-manager: setting walker theme to \"{}\"", theme_name);
+  }
+
+  fs::write(&config_path, new_lines.join("\n") + "\n")?;
+  Ok(())
+}
+
+fn apply_copy(
+  ctx: &CommandContext<'_>,
+  theme_dir: &Path,
+  style_path: &Path,
+  layout_path: &Path,
+) -> Result<()> {
+  // Create a temporary theme directory in walker themes
+  let temp_theme_name = "theme-manager-auto";
+  let dest_theme_dir = ctx.config.walker_themes_dir.join(temp_theme_name);
+  fs::create_dir_all(&dest_theme_dir)?;
+
+  if !ctx.quiet {
+    println!(
+      "theme-manager: copying walker theme from {}",
+      theme_dir.to_string_lossy()
+    );
+  }
+
+  // Copy style.css
+  let dest_style = dest_theme_dir.join("style.css");
+  fs::copy(style_path, &dest_style)?;
+
+  // Copy layout.xml if it exists
+  if layout_path.is_file() {
+    let dest_layout = dest_theme_dir.join("layout.xml");
+    fs::copy(layout_path, &dest_layout)?;
+  }
+
+  // Copy any other theme files (like hyprland_animations.conf)
+  for entry in fs::read_dir(theme_dir)? {
+    let entry = entry?;
+    let path = entry.path();
+    if path.is_file() {
+      let name = path.file_name().unwrap();
+      let dest = dest_theme_dir.join(name);
+      if !dest.exists() {
+        fs::copy(&path, &dest)?;
+      }
+    }
+  }
+
+  // Update walker config to use this theme
+  update_walker_config(ctx, temp_theme_name)?;
+
+  Ok(())
+}
+
+fn apply_symlink(
+  ctx: &CommandContext<'_>,
+  theme_dir: &Path,
+  style_path: &Path,
+  layout_path: &Path,
+) -> Result<()> {
+  // Create a temporary theme directory in walker themes with symlinks
+  let temp_theme_name = "theme-manager-auto";
+  let dest_theme_dir = ctx.config.walker_themes_dir.join(temp_theme_name);
+
+  // Remove old auto theme if it exists
+  if dest_theme_dir.exists() {
+    fs::remove_dir_all(&dest_theme_dir)?;
+  }
+  fs::create_dir_all(&dest_theme_dir)?;
+
+  if !ctx.quiet {
+    println!(
+      "theme-manager: linking walker theme from {}",
+      theme_dir.to_string_lossy()
+    );
+  }
+
+  // Symlink style.css
+  let dest_style = dest_theme_dir.join("style.css");
+  std::os::unix::fs::symlink(style_path, &dest_style)?;
+
+  // Symlink layout.xml if it exists
+  if layout_path.is_file() {
+    let dest_layout = dest_theme_dir.join("layout.xml");
+    std::os::unix::fs::symlink(layout_path, &dest_layout)?;
+  }
+
+  // Symlink any other theme files
+  for entry in fs::read_dir(theme_dir)? {
+    let entry = entry?;
+    let path = entry.path();
+    if path.is_file() {
+      let name = path.file_name().unwrap();
+      let dest = dest_theme_dir.join(name);
+      if !dest.exists() {
+        std::os::unix::fs::symlink(&path, &dest)?;
+      }
+    }
+  }
+
+  // Update walker config to use this theme
+  update_walker_config(ctx, temp_theme_name)?;
+
+  // Record that we created this theme dir for cleanup
+  let manifest_path = ctx.config.walker_dir.join(WALKER_LINKS_FILE);
+  fs::write(&manifest_path, temp_theme_name)?;
+
+  Ok(())
+}
+
+fn cleanup_walker_links(walker_dir: &Path, quiet: bool) -> Result<()> {
+  let manifest_path = walker_dir.join(WALKER_LINKS_FILE);
+  if !manifest_path.is_file() {
+    return Ok(());
+  }
+
+  let content = fs::read_to_string(&manifest_path)?;
+  for line in content.lines() {
+    let name = line.trim();
+    if name.is_empty() {
+      continue;
+    }
+    let path = walker_dir.join(name);
+    let meta = match fs::symlink_metadata(&path) {
+      Ok(meta) => meta,
+      Err(_) => continue,
+    };
+    if !meta.file_type().is_symlink() {
+      continue;
+    }
+    if !quiet {
+      println!("theme-manager: removing walker link {}", path.to_string_lossy());
+    }
+    let _ = fs::remove_file(&path);
+  }
+
+  let _ = fs::remove_file(&manifest_path);
+  Ok(())
+}

--- a/rust/tests/cli_walker.rs
+++ b/rust/tests/cli_walker.rs
@@ -1,0 +1,154 @@
+mod support;
+
+use support::*;
+use std::fs;
+
+#[test]
+fn walker_apply_named_updates_config() {
+  let env = setup_env();
+  add_omarchy_stubs(&env.bin);
+  let themes = omarchy_dir(&env.home).join("themes");
+  fs::create_dir_all(themes.join("theme-a")).unwrap();
+
+  // Create a walker theme
+  let walker_theme = env.home.join(".config/walker/themes/shared");
+  fs::create_dir_all(&walker_theme).unwrap();
+  fs::write(walker_theme.join("style.css"), "style").unwrap();
+
+  // Create walker config
+  let walker_dir = env.home.join(".config/walker");
+  fs::create_dir_all(&walker_dir).unwrap();
+  fs::write(walker_dir.join("config.toml"), "theme = \"old\"\n").unwrap();
+
+  let cfg_dir = env.home.join(".config/theme-manager");
+  fs::create_dir_all(&cfg_dir).unwrap();
+  write_toml(
+    &cfg_dir.join("config.toml"),
+    r#"[walker]
+default_mode = "named"
+default_name = "shared"
+"#,
+  );
+
+  let mut cmd = cmd_with_env(&env);
+  cmd.env_remove("THEME_MANAGER_SKIP_APPS");
+  cmd.args(["set", "theme-a"]);
+  cmd.assert().success();
+
+  // Verify the walker config was updated
+  let config_content = fs::read_to_string(walker_dir.join("config.toml")).unwrap();
+  assert!(config_content.contains("theme = \"shared\""));
+}
+
+#[test]
+fn walker_apply_auto_creates_theme_dir() {
+  let env = setup_env();
+  add_omarchy_stubs(&env.bin);
+  let themes = omarchy_dir(&env.home).join("themes");
+  let theme_dir = themes.join("theme-a/walker-theme");
+  fs::create_dir_all(&theme_dir).unwrap();
+  fs::write(theme_dir.join("style.css"), "style").unwrap();
+  fs::write(theme_dir.join("layout.xml"), "<layout/>").unwrap();
+
+  // Create walker config
+  let walker_dir = env.home.join(".config/walker");
+  fs::create_dir_all(&walker_dir).unwrap();
+  fs::write(walker_dir.join("config.toml"), "theme = \"old\"\n").unwrap();
+
+  // Create walker themes dir
+  let walker_themes = walker_dir.join("themes");
+  fs::create_dir_all(&walker_themes).unwrap();
+
+  let cfg_dir = env.home.join(".config/theme-manager");
+  fs::create_dir_all(&cfg_dir).unwrap();
+  write_toml(
+    &cfg_dir.join("config.toml"),
+    r#"[walker]
+apply_mode = "symlink"
+default_mode = "auto"
+"#,
+  );
+
+  let mut cmd = cmd_with_env(&env);
+  cmd.env_remove("THEME_MANAGER_SKIP_APPS");
+  cmd.args(["set", "theme-a"]);
+  cmd.assert().success();
+
+  // Verify the auto theme was created
+  let auto_theme = walker_themes.join("theme-manager-auto");
+  assert!(auto_theme.is_dir());
+  assert!(auto_theme.join("style.css").exists());
+
+  // Verify config was updated
+  let config_content = fs::read_to_string(walker_dir.join("config.toml")).unwrap();
+  assert!(config_content.contains("theme = \"theme-manager-auto\""));
+}
+
+#[test]
+fn walker_standalone_command() {
+  let env = setup_env();
+  add_omarchy_stubs(&env.bin);
+  let themes = omarchy_dir(&env.home).join("themes");
+  fs::create_dir_all(themes.join("theme-a")).unwrap();
+
+  // Set up current theme link
+  let current_dir = env.home.join(".config/omarchy/current");
+  fs::create_dir_all(&current_dir).unwrap();
+  #[cfg(unix)]
+  std::os::unix::fs::symlink(themes.join("theme-a"), current_dir.join("theme")).unwrap();
+  fs::write(current_dir.join("theme.name"), "theme-a").unwrap();
+
+  // Create a walker theme
+  let walker_themes = env.home.join(".config/walker/themes");
+  let walker_theme = walker_themes.join("minimal");
+  fs::create_dir_all(&walker_theme).unwrap();
+  fs::write(walker_theme.join("style.css"), "minimal-style").unwrap();
+
+  // Create walker config
+  let walker_dir = env.home.join(".config/walker");
+  fs::write(walker_dir.join("config.toml"), "theme = \"old\"\n").unwrap();
+
+  let cfg_dir = env.home.join(".config/theme-manager");
+  fs::create_dir_all(&cfg_dir).unwrap();
+  write_toml(&cfg_dir.join("config.toml"), "");
+
+  let mut cmd = cmd_with_env(&env);
+  cmd.env_remove("THEME_MANAGER_SKIP_APPS");
+  cmd.args(["walker", "minimal"]);
+  cmd.assert().success();
+
+  // Verify config was updated
+  let config_content = fs::read_to_string(walker_dir.join("config.toml")).unwrap();
+  assert!(config_content.contains("theme = \"minimal\""));
+}
+
+#[test]
+fn walker_none_skips_theme() {
+  let env = setup_env();
+  add_omarchy_stubs(&env.bin);
+  let themes = omarchy_dir(&env.home).join("themes");
+  fs::create_dir_all(themes.join("theme-a")).unwrap();
+
+  // Create walker config with existing theme
+  let walker_dir = env.home.join(".config/walker");
+  fs::create_dir_all(&walker_dir).unwrap();
+  fs::write(walker_dir.join("config.toml"), "theme = \"original\"\n").unwrap();
+
+  let cfg_dir = env.home.join(".config/theme-manager");
+  fs::create_dir_all(&cfg_dir).unwrap();
+  write_toml(
+    &cfg_dir.join("config.toml"),
+    r#"[walker]
+default_mode = ""
+"#,
+  );
+
+  let mut cmd = cmd_with_env(&env);
+  cmd.env_remove("THEME_MANAGER_SKIP_APPS");
+  cmd.args(["set", "theme-a"]);
+  cmd.assert().success();
+
+  // Verify config was NOT changed
+  let config_content = fs::read_to_string(walker_dir.join("config.toml")).unwrap();
+  assert!(config_content.contains("theme = \"original\""));
+}


### PR DESCRIPTION
## Summary
- Add Walker (GTK application launcher) theme management
- New `walker.rs` module with symlink/copy modes  
- Walker tab in TUI browser with preview
- CLI subcommand: `theme-manager walker <mode>`
- Preset support with walker field
- Config options: `walker_dir`, `walker_themes_dir`, `apply_mode`, defaults

Walker themes use `style.css` + `layout.xml`. Named themes update the `theme` setting in Walker's config.toml. Auto mode creates a `theme-manager-auto` theme directory for theme-bundled walker configs.

## Test plan
- [x] `cargo test --test cli_walker` - 4 tests pass
- [x] `theme-manager walker <name>` switches themes
- [x] TUI shows Walker tab with theme list and preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)