### PR TITLE
unify omarchy defaults resolution and fix tui previews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ No commit message convention is enforced. Use concise, present-tense messages (e
 
 ## Architecture Notes
 Follow the compatibility requirements outlined in `Omarchy-theme-management.md`. Maintain the current theme and background symlinks under `~/.config/omarchy/current/`, reload user-facing components, and trigger `omarchy-hook theme-set` after switching.
+Omarchy default component discovery for Waybar/Walker/Hyprlock/Starship is centralized in `rust/src/omarchy_defaults.rs`; keep module behavior aligned to this shared resolver instead of adding per-module fallback probing.
 
 ## Configuration
 Defaults can be set via `~/.config/theme-manager/config.toml` or `./.theme-manager.toml`. Local config overrides user config; CLI flags override both.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project are documented in this file.
   - deleted Bash config samples (`config.example`, `./.theme-manager.conf`)
   - deleted legacy Bats tests under `tests/`
 - Updated repository docs and contributor guidelines to reflect Rust-only CLI/TUI workflows.
+- Unified Omarchy default component resolution for Waybar/Walker/Hyprlock/Starship through a shared resolver:
+  - standardized cross-module fallback precedence and validation checks
+  - repaired stale `omarchy-default` symlinks automatically when targets drift
+  - added regression coverage for precedence and missing-default behavior
 
 ## 0.3.0
 

--- a/OMARCHY_DEFAULTS_UNIFICATION_PLAN.md
+++ b/OMARCHY_DEFAULTS_UNIFICATION_PLAN.md
@@ -1,0 +1,182 @@
+# Omarchy Default Settings Unification Plan
+
+## Goal
+Unify how all Theme Manager+ module tabs and CLI flows load Omarchy default settings so behavior consistently resolves from Omarchy base files across supported Omarchy layouts/versions.
+
+## Scope
+- In scope: Waybar, Walker, Hyprlock, Starship default-source discovery and application paths used by TUI tabs and CLI (`set`, `next`, `browse`, `preset load`, module-only commands).
+- In scope: shared resolver logic, tests, and docs.
+- Out of scope: changing Omarchy files in `~/.local/share/omarchy/` (read-only source), UI redesign, non-default custom theme behavior.
+
+## Tracking
+- Status values: `Not Started`, `In Progress`, `Blocked`, `Done`
+- Update each phase header with current status during execution.
+
+---
+
+## Phase 1 - Baseline Audit (Status: Done)
+### Objective
+Produce a concrete map of current default-resolution behavior per module and per flow.
+
+### Actionable Items
+- [x] Inventory all current default resolvers and callers in Rust:
+  - [x] `rust/src/waybar.rs`
+  - [x] `rust/src/walker.rs`
+  - [x] `rust/src/hyprlock.rs`
+  - [x] `rust/src/starship.rs`
+  - [x] `rust/src/tui.rs`
+  - [x] `rust/src/lib.rs`
+  - [x] `rust/src/theme_ops.rs`
+  - [x] `rust/src/omarchy.rs`
+- [x] Create a matrix of current fallback order per module (actual behavior, not intended behavior).
+- [x] Identify behavior mismatches between:
+  - [x] TUI tab item availability
+  - [x] CLI default application
+  - [x] Module-only commands
+- [x] Record test coverage currently present and missing by module/layout.
+
+### Deliverables
+- [x] Audit matrix document added to repo (`docs/omarchy-default-audit.md` or equivalent).
+- [x] List of concrete divergence bugs/risks with file references.
+
+### Exit Criteria
+- [x] We can answer, for every module, "what exact file path is picked first, second, third" for each Omarchy layout.
+
+---
+
+## Phase 2 - Canonical Resolution Spec (Status: Done)
+### Objective
+Define one canonical resolution contract that is version-aware and shared.
+
+### Actionable Items
+- [x] Define supported Omarchy layout candidates per module (ordered precedence).
+- [x] Define root detection precedence:
+  - [x] `OMARCHY_PATH`
+  - [x] configured `omarchy_bin_dir`
+  - [x] `~/.local/share/omarchy`
+- [x] Define resolver return contract (e.g., `Option<ResolvedDefault>` with path + source-kind metadata).
+- [x] Define missing-file behavior:
+  - [x] silent skip vs warning
+  - [x] when to show/no-show in TUI lists
+- [x] Define compatibility policy for older/newer Omarchy versions.
+
+### Deliverables
+- [x] Canonical spec doc committed (`docs/omarchy-default-resolution-spec.md`).
+- [x] Sign-off checklist embedded in doc.
+
+### Exit Criteria
+- [x] Every module can consume the same contract without special-case path probing.
+
+---
+
+## Phase 3 - Shared Resolver Implementation (Status: Done)
+### Objective
+Implement one internal resolver module and remove duplicated probing logic.
+
+### Actionable Items
+- [x] Add new module (example): `rust/src/omarchy_defaults.rs`.
+- [x] Implement shared functions:
+  - [x] `resolve_waybar_default(...)`
+  - [x] `resolve_walker_default(...)`
+  - [x] `resolve_hyprlock_default(...)`
+  - [x] `resolve_starship_default(...)`
+- [x] Centralize candidate-path generation and existence checks.
+- [x] Reuse/centralize Omarchy root detection.
+- [x] Add structured debug logging hooks (quiet-aware).
+- [x] Keep behavior non-destructive and reversible.
+
+### Deliverables
+- [x] New resolver module with unit-testable helpers.
+- [x] No module-level duplicated fallback probing remains.
+
+### Exit Criteria
+- [x] One source of truth exists for default resolution and compiles cleanly.
+
+---
+
+## Phase 4 - Integration Across Tabs and Commands (Status: Done)
+### Objective
+Wire all tabs and CLI command paths to the shared resolver.
+
+### Actionable Items
+- [x] Update module handlers to consume shared resolver:
+  - [x] `waybar::ensure_omarchy_default_theme_link`
+  - [x] `walker::ensure_omarchy_default_theme_link`
+  - [x] `hyprlock::ensure_omarchy_default_theme_link`
+  - [x] `starship::ensure_omarchy_default_theme_link`
+- [x] Update TUI builders to rely on shared resolution outcomes:
+  - [x] `build_waybar_items`
+  - [x] `build_walker_items`
+  - [x] `build_hyprlock_items`
+  - [x] `build_starship_items`
+- [x] Validate parity between:
+  - [x] `browse` apply path
+  - [x] `set`/`next`
+  - [x] `preset load`
+  - [x] module-only subcommands
+- [x] Preserve Omarchy-safe behavior (read-only in `~/.local/share/omarchy/`).
+
+### Deliverables
+- [x] Unified behavior in runtime code paths.
+- [x] No TUI/CLI mismatch for `omarchy-default` availability and target selection.
+
+### Exit Criteria
+- [x] Same input environment produces same resolved default path across all flows.
+
+---
+
+## Phase 5 - Test Matrix Expansion (Status: In Progress)
+### Objective
+Add regression tests that prove cross-version compatibility and unified behavior.
+
+### Actionable Items
+- [ ] Add/expand table-driven tests for each module default resolver:
+  - [x] layout variant A: `default/<module>` style
+  - [x] layout variant B: `default/<module>/themes/omarchy-default`
+  - [x] layout variant C: theme-root fallback where applicable
+  - [x] missing paths behavior
+- [ ] Add integration tests validating TUI list and CLI apply parity.
+- [x] Add precedence tests where multiple candidates exist.
+- [x] Ensure tests remain hermetic under `rust/tests/support`.
+- [x] Run full test suite and capture results.
+
+### Deliverables
+- [ ] New tests in `rust/tests/` with clear naming by module/behavior.
+- [ ] Updated coverage notes in tracking doc.
+
+### Exit Criteria
+- [ ] Failing test reproduces any future regression in resolver precedence/parity.
+
+---
+
+## Phase 6 - Documentation and Rollout (Status: In Progress)
+### Objective
+Document final behavior and prepare release notes.
+
+### Actionable Items
+- [x] Update `README.md` with canonical default-resolution behavior.
+- [x] Update `AGENTS.md` contributor guidance for Omarchy default loading.
+- [x] Add changelog entry under `## Unreleased` in `CHANGELOG.md`.
+- [ ] If version bump is included, update `VERSION` and `RELEASE_NOTES.md`.
+- [x] Include troubleshooting notes for users with non-standard Omarchy layouts.
+
+### Deliverables
+- [ ] User-facing docs aligned with implemented behavior.
+- [ ] Release notes reflect functional impact.
+
+### Exit Criteria
+- [ ] A maintainer can verify behavior from docs alone.
+
+---
+
+## Cross-Phase Risk Controls
+- [ ] Never modify files under `~/.local/share/omarchy/`.
+- [ ] Prefer smallest reversible changes first.
+- [ ] Keep all path probing explicit and test-backed.
+- [ ] Preserve existing behavior unless mismatch/bug is intentional and documented.
+
+## Definition of Done
+- [ ] Shared resolver is the only source for Omarchy default discovery.
+- [ ] TUI tabs and CLI flows are behaviorally consistent.
+- [ ] Multi-layout compatibility is covered by tests.
+- [ ] Docs/changelog updated and accurate.

--- a/README.md
+++ b/README.md
@@ -354,6 +354,33 @@ Supports Omarchy templates via:
 - `$OMARCHY_PATH/default/themed`
 - `~/.config/omarchy/themed` (user overrides)
 
+### Omarchy Default Source Resolution
+
+`omarchy-default` component discovery is unified across CLI and TUI.
+
+Root detection order:
+1. `OMARCHY_PATH`
+2. configured `omarchy_bin_dir` parent
+3. `~/.local/share/omarchy`
+
+Module default precedence:
+- Waybar: `default/waybar/themes/omarchy-default` -> `default/waybar`
+- Walker: `default/walker/themes/omarchy-default` -> `default/walker`
+- Hyprlock: `default/hyprlock/themes/omarchy-default` -> `default/hyprlock` -> `themes/omarchy-default` -> `config/hypr` -> user config fallbacks under `~/.config/omarchy/`
+- Starship: `default/starship/themes/omarchy-default.toml` -> `default/starship.toml` -> `default/starship/starship.toml`
+
+Validation rules:
+- Waybar requires both `config.jsonc` and `style.css`
+- Walker requires `style.css`
+- Hyprlock requires `hyprlock.conf`
+- Starship requires a `.toml` file
+
+Troubleshooting non-standard Omarchy layouts:
+- If your Omarchy root is not `~/.local/share/omarchy`, set `OMARCHY_PATH` explicitly.
+- If helper commands are installed in a custom bin location, set `OMARCHY_BIN_DIR`.
+- Use `theme-manager print-config` to verify resolved paths before applying themes.
+- If `omarchy-default` is missing from tabs, confirm required module files exist at one of the supported paths above.
+
 ---
 
 ## Configuration

--- a/docs/omarchy-default-audit.md
+++ b/docs/omarchy-default-audit.md
@@ -1,0 +1,74 @@
+# Omarchy Default Resolution Audit (Phase 1)
+
+## Purpose
+Capture **current implemented behavior** for Omarchy default loading across module tabs and CLI flows.
+
+## Root Detection (Shared)
+Current Omarchy root detection is centralized in `detect_omarchy_root`:
+1. `OMARCHY_PATH`
+2. `config.omarchy_bin_dir` parent
+3. `$HOME/.local/share/omarchy`
+
+Reference: [omarchy.rs](/home/oldjobobo/Projects/rust/theme-manager-plus/rust/src/omarchy.rs:28)
+
+## Current Resolver Matrix (As Implemented)
+
+| Module | Resolver Function | Candidate Order (first hit wins) | Validation |
+|---|---|---|---|
+| Waybar | `omarchy_default_waybar_theme_dir` | `default/waybar/themes/omarchy-default` -> `default/waybar` | Must contain both `config.jsonc` and `style.css` |
+| Walker | `omarchy_default_walker_theme_dir` | `default/walker/themes/omarchy-default` | Directory exists only |
+| Hyprlock | `omarchy_default_hyprlock_theme_dir` | `default/hyprlock/themes/omarchy-default` -> `default/hyprlock` -> `themes/omarchy-default` -> `config/hypr` -> `$HOME/.config/omarchy/default/hyprlock/themes/omarchy-default` -> `$HOME/.config/omarchy/default/hyprlock` -> `$HOME/.config/omarchy/themes/omarchy-default` -> `$HOME/.config/omarchy/config/hypr` | Must contain `hyprlock.conf` |
+| Starship | `omarchy_default_starship_theme_file` | `default/starship/themes/omarchy-default.toml` -> `default/starship.toml` -> `default/starship/starship.toml` | File exists |
+
+References:
+- [waybar.rs](/home/oldjobobo/Projects/rust/theme-manager-plus/rust/src/waybar.rs:89)
+- [walker.rs](/home/oldjobobo/Projects/rust/theme-manager-plus/rust/src/walker.rs:100)
+- [hyprlock.rs](/home/oldjobobo/Projects/rust/theme-manager-plus/rust/src/hyprlock.rs:183)
+- [starship.rs](/home/oldjobobo/Projects/rust/theme-manager-plus/rust/src/starship.rs:130)
+
+## Where Defaults Are Consumed
+- CLI default mode parsing uses `*_from_defaults` when flags are omitted.
+  - Reference: [theme_ops.rs](/home/oldjobobo/Projects/rust/theme-manager-plus/rust/src/theme_ops.rs:63)
+  - Reference: [lib.rs](/home/oldjobobo/Projects/rust/theme-manager-plus/rust/src/lib.rs:260)
+- TUI tab builders call `ensure_omarchy_default_theme_link` for each module before listing options.
+  - Reference: [tui.rs](/home/oldjobobo/Projects/rust/theme-manager-plus/rust/src/tui.rs:1151)
+
+## Divergences / Risks Identified
+1. Inconsistent fallback breadth across modules.
+- Hyprlock supports many layouts (including config-space fallbacks), while Walker is strict (single path), and Waybar/Starship are mid-range.
+
+2. Hyprlock tab behavior is special-cased; others are not.
+- Hyprlock appends `omarchy-default` in TUI if `omarchy_default_theme_available()` is true even when the link is absent.
+- Waybar/Walker/Starship rely solely on linked directory listing.
+- Reference: [tui.rs](/home/oldjobobo/Projects/rust/theme-manager-plus/rust/src/tui.rs:1296)
+
+3. Existing link is treated as valid without target verification.
+- All `ensure_omarchy_default_theme_link` functions return early if link path exists; stale or wrong symlink is not corrected.
+
+4. Walker resolver validates only directory existence.
+- Resolver does not require `style.css`; invalid default dir can be linked and later rejected during apply.
+- Reference: [walker.rs](/home/oldjobobo/Projects/rust/theme-manager-plus/rust/src/walker.rs:105)
+
+5. Version compatibility handling is ad hoc per module.
+- Candidate paths differ by module without a shared version policy or explicit source-kind metadata.
+
+## Current Test Coverage Snapshot
+
+| Module | Default-path tests present | Notable gaps |
+|---|---|---|
+| Waybar | Tests `.local/share/omarchy/default/waybar` link path | No precedence tests when multiple candidates exist |
+| Walker | Tests `.local/share/omarchy/default/walker/themes/omarchy-default` | No alternate/fallback layout tests |
+| Hyprlock | Tests multiple fallbacks (`default/hyprlock`, `themes/omarchy-default`, `config/hypr`, config-space paths) | No explicit precedence conflict test matrix |
+| Starship | Tests `.local/share/omarchy/default/starship.toml` | No `default/starship/themes/omarchy-default.toml` precedence test |
+
+References:
+- [cli_waybar.rs](/home/oldjobobo/Projects/rust/theme-manager-plus/rust/tests/cli_waybar.rs:173)
+- [cli_walker.rs](/home/oldjobobo/Projects/rust/theme-manager-plus/rust/tests/cli_walker.rs:309)
+- [cli_hyprlock.rs](/home/oldjobobo/Projects/rust/theme-manager-plus/rust/tests/cli_hyprlock.rs:105)
+- [cli_starship.rs](/home/oldjobobo/Projects/rust/theme-manager-plus/rust/tests/cli_starship.rs:129)
+
+## Phase 1 Recommendation Summary
+- Move all candidate probing into one shared resolver layer.
+- Define one explicit precedence policy per module in a canonical spec.
+- Standardize link integrity checks (exists + valid target semantics).
+- Align TUI option visibility behavior across modules.

--- a/docs/omarchy-default-resolution-spec.md
+++ b/docs/omarchy-default-resolution-spec.md
@@ -1,0 +1,104 @@
+# Omarchy Default Resolution Spec (Phase 2)
+
+## Status
+Proposed canonical contract for unified resolver implementation.
+
+## Objective
+Define one shared, version-aware policy for resolving Omarchy default assets used by Theme Manager+ module tabs and CLI flows.
+
+## Non-Negotiables
+- Read-only interaction with Omarchy base in `~/.local/share/omarchy`.
+- No writes outside Theme Manager+ managed destinations.
+- Consistent behavior between TUI and CLI for default discovery and use.
+
+## Root Detection Precedence
+Resolver root precedence must be:
+1. `OMARCHY_PATH` (non-empty)
+2. `ResolvedConfig.omarchy_bin_dir` parent
+3. `$HOME/.local/share/omarchy`
+
+Reference baseline: [omarchy.rs](/home/oldjobobo/Projects/rust/theme-manager-plus/rust/src/omarchy.rs:28)
+
+## Resolver Contract
+All module resolvers return this conceptual shape:
+
+- `None` if no valid default candidate exists.
+- `Some(ResolvedOmarchyDefault)` when found:
+  - `path`: resolved filesystem path
+  - `kind`: source category
+  - `module`: `waybar | walker | hyprlock | starship`
+  - `validation`: checks applied (for diagnostics)
+
+Recommended source kind enum:
+- `OmarchyDefaultNamed`
+- `OmarchyDefaultBase`
+- `OmarchyThemeStoreDefault`
+- `OmarchyConfigFallback`
+- `OmarchyUserConfigFallback`
+
+## Validation Rules
+- Waybar default candidate is valid only if both `config.jsonc` and `style.css` exist.
+- Walker default candidate is valid only if `style.css` exists.
+- Hyprlock default candidate is valid only if `hyprlock.conf` exists.
+- Starship default candidate is valid only if target `.toml` file exists.
+
+## Canonical Candidate Precedence by Module
+
+### Waybar
+1. `<root>/default/waybar/themes/omarchy-default`
+2. `<root>/default/waybar`
+
+### Walker
+1. `<root>/default/walker/themes/omarchy-default`
+2. `<root>/default/walker`
+
+### Hyprlock
+1. `<root>/default/hyprlock/themes/omarchy-default`
+2. `<root>/default/hyprlock`
+3. `<root>/themes/omarchy-default`
+4. `<root>/config/hypr`
+5. `$HOME/.config/omarchy/default/hyprlock/themes/omarchy-default`
+6. `$HOME/.config/omarchy/default/hyprlock`
+7. `$HOME/.config/omarchy/themes/omarchy-default`
+8. `$HOME/.config/omarchy/config/hypr`
+
+### Starship
+1. `<root>/default/starship/themes/omarchy-default.toml`
+2. `<root>/default/starship.toml`
+3. `<root>/default/starship/starship.toml`
+
+## Link/Create Behavior
+- `ensure_omarchy_default_theme_link`-style flows must:
+1. Resolve default with shared resolver.
+2. If destination link/file does not exist, create symlink.
+3. If destination exists but is a broken symlink or wrong target, repair it.
+4. If destination exists as regular file/dir, preserve and warn; do not destructively replace without explicit apply path.
+
+## TUI Visibility Rules
+- TUI module tabs must derive `omarchy-default` visibility from shared resolver output only.
+- No module-specific visibility exceptions.
+- If resolver returns `None`, do not show `omarchy-default` in the tab list.
+
+## CLI Parity Rules
+- `set`, `next`, `preset load`, and module-only commands must all use the same shared resolver and link-integrity checks.
+- Given identical filesystem/config state, resolved default target must be identical across all command paths.
+
+## Logging/Warn Policy
+- Quiet mode: suppress informational logs.
+- Non-quiet mode:
+  - log link creation/repair with source and destination.
+  - warn once when destination exists but cannot be safely repaired automatically.
+
+## Compatibility Policy
+- Prefer newest known Omarchy default layout first.
+- Keep fallback support for older observed layouts where safe and file-validated.
+- Do not assume every Omarchy install has every module default.
+
+## Sign-off Checklist
+- [x] Root precedence defined.
+- [x] Resolver return contract defined.
+- [x] Module-specific candidate order defined.
+- [x] Validation requirements defined.
+- [x] TUI/CLI parity rules defined.
+- [x] Link integrity behavior defined.
+- [x] Compatibility policy defined.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod git_ops;
 pub mod hyprlock;
 pub mod omarchy;
+pub mod omarchy_defaults;
 pub mod paths;
 pub mod presets;
 pub mod preview;

--- a/rust/src/omarchy_defaults.rs
+++ b/rust/src/omarchy_defaults.rs
@@ -1,0 +1,242 @@
+use anyhow::Result;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use crate::config::ResolvedConfig;
+use crate::omarchy;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefaultModule {
+  Waybar,
+  Walker,
+  Hyprlock,
+  Starship,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefaultSourceKind {
+  OmarchyDefaultNamed,
+  OmarchyDefaultBase,
+  OmarchyThemeStoreDefault,
+  OmarchyConfigFallback,
+  OmarchyUserConfigFallback,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedOmarchyDefault {
+  pub module: DefaultModule,
+  pub path: PathBuf,
+  pub kind: DefaultSourceKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SymlinkEnsureResult {
+  Created,
+  Updated,
+  Unchanged,
+  SkippedNonSymlink,
+}
+
+pub fn resolve_waybar_default(config: &ResolvedConfig) -> Option<ResolvedOmarchyDefault> {
+  let root = omarchy::detect_omarchy_root(config)?;
+
+  let named = root.join("default/waybar/themes/omarchy-default");
+  if is_waybar_theme_dir(&named) {
+    return Some(ResolvedOmarchyDefault {
+      module: DefaultModule::Waybar,
+      path: named,
+      kind: DefaultSourceKind::OmarchyDefaultNamed,
+    });
+  }
+
+  let base = root.join("default/waybar");
+  if is_waybar_theme_dir(&base) {
+    return Some(ResolvedOmarchyDefault {
+      module: DefaultModule::Waybar,
+      path: base,
+      kind: DefaultSourceKind::OmarchyDefaultBase,
+    });
+  }
+
+  let config_fallback = root.join("config/waybar");
+  if is_waybar_theme_dir(&config_fallback) {
+    return Some(ResolvedOmarchyDefault {
+      module: DefaultModule::Waybar,
+      path: config_fallback,
+      kind: DefaultSourceKind::OmarchyConfigFallback,
+    });
+  }
+
+  None
+}
+
+pub fn resolve_walker_default(config: &ResolvedConfig) -> Option<ResolvedOmarchyDefault> {
+  let root = omarchy::detect_omarchy_root(config)?;
+
+  let named = root.join("default/walker/themes/omarchy-default");
+  if is_walker_theme_dir(&named) {
+    return Some(ResolvedOmarchyDefault {
+      module: DefaultModule::Walker,
+      path: named,
+      kind: DefaultSourceKind::OmarchyDefaultNamed,
+    });
+  }
+
+  let base = root.join("default/walker");
+  if is_walker_theme_dir(&base) {
+    return Some(ResolvedOmarchyDefault {
+      module: DefaultModule::Walker,
+      path: base,
+      kind: DefaultSourceKind::OmarchyDefaultBase,
+    });
+  }
+
+  None
+}
+
+pub fn resolve_hyprlock_default(config: &ResolvedConfig) -> Option<ResolvedOmarchyDefault> {
+  let mut candidates: Vec<(PathBuf, DefaultSourceKind)> = Vec::new();
+
+  if let Some(root) = omarchy::detect_omarchy_root(config) {
+    candidates.push((
+      root.join("default/hyprlock/themes/omarchy-default"),
+      DefaultSourceKind::OmarchyDefaultNamed,
+    ));
+    candidates.push((
+      root.join("default/hyprlock"),
+      DefaultSourceKind::OmarchyDefaultBase,
+    ));
+    candidates.push((
+      root.join("themes/omarchy-default"),
+      DefaultSourceKind::OmarchyThemeStoreDefault,
+    ));
+    candidates.push((
+      root.join("config/hypr"),
+      DefaultSourceKind::OmarchyConfigFallback,
+    ));
+  }
+
+  if let Ok(home) = std::env::var("HOME") {
+    let home = PathBuf::from(home);
+    candidates.push((
+      home.join(".config/omarchy/default/hyprlock/themes/omarchy-default"),
+      DefaultSourceKind::OmarchyUserConfigFallback,
+    ));
+    candidates.push((
+      home.join(".config/omarchy/default/hyprlock"),
+      DefaultSourceKind::OmarchyUserConfigFallback,
+    ));
+    candidates.push((
+      home.join(".config/omarchy/themes/omarchy-default"),
+      DefaultSourceKind::OmarchyUserConfigFallback,
+    ));
+    candidates.push((
+      home.join(".config/omarchy/config/hypr"),
+      DefaultSourceKind::OmarchyUserConfigFallback,
+    ));
+  }
+
+  for (path, kind) in candidates {
+    if path.join("hyprlock.conf").is_file() {
+      return Some(ResolvedOmarchyDefault {
+        module: DefaultModule::Hyprlock,
+        path,
+        kind,
+      });
+    }
+  }
+
+  None
+}
+
+pub fn resolve_starship_default(config: &ResolvedConfig) -> Option<ResolvedOmarchyDefault> {
+  let root = omarchy::detect_omarchy_root(config)?;
+
+  let named = root.join("default/starship/themes/omarchy-default.toml");
+  if named.is_file() {
+    return Some(ResolvedOmarchyDefault {
+      module: DefaultModule::Starship,
+      path: named,
+      kind: DefaultSourceKind::OmarchyDefaultNamed,
+    });
+  }
+
+  let base = root.join("default/starship.toml");
+  if base.is_file() {
+    return Some(ResolvedOmarchyDefault {
+      module: DefaultModule::Starship,
+      path: base,
+      kind: DefaultSourceKind::OmarchyDefaultBase,
+    });
+  }
+
+  let nested = root.join("default/starship/starship.toml");
+  if nested.is_file() {
+    return Some(ResolvedOmarchyDefault {
+      module: DefaultModule::Starship,
+      path: nested,
+      kind: DefaultSourceKind::OmarchyConfigFallback,
+    });
+  }
+
+  let config_fallback = root.join("config/starship.toml");
+  if config_fallback.is_file() {
+    return Some(ResolvedOmarchyDefault {
+      module: DefaultModule::Starship,
+      path: config_fallback,
+      kind: DefaultSourceKind::OmarchyConfigFallback,
+    });
+  }
+
+  None
+}
+
+pub fn ensure_symlink(link_path: &Path, target: &Path) -> Result<SymlinkEnsureResult> {
+  match fs::symlink_metadata(link_path) {
+    Ok(meta) => {
+      if !meta.file_type().is_symlink() {
+        return Ok(SymlinkEnsureResult::SkippedNonSymlink);
+      }
+
+      let current_target = fs::read_link(link_path)?;
+      if current_target == target {
+        return Ok(SymlinkEnsureResult::Unchanged);
+      }
+
+      fs::remove_file(link_path)?;
+      #[cfg(unix)]
+      {
+        std::os::unix::fs::symlink(target, link_path)?;
+      }
+      #[cfg(not(unix))]
+      {
+        fs::copy(target, link_path)?;
+      }
+      Ok(SymlinkEnsureResult::Updated)
+    }
+    Err(err) if err.kind() == ErrorKind::NotFound => {
+      if let Some(parent) = link_path.parent() {
+        fs::create_dir_all(parent)?;
+      }
+      #[cfg(unix)]
+      {
+        std::os::unix::fs::symlink(target, link_path)?;
+      }
+      #[cfg(not(unix))]
+      {
+        fs::copy(target, link_path)?;
+      }
+      Ok(SymlinkEnsureResult::Created)
+    }
+    Err(err) => Err(err.into()),
+  }
+}
+
+fn is_waybar_theme_dir(path: &Path) -> bool {
+  path.join("config.jsonc").is_file() && path.join("style.css").is_file()
+}
+
+fn is_walker_theme_dir(path: &Path) -> bool {
+  path.join("style.css").is_file()
+}


### PR DESCRIPTION
## Summary
- unify Omarchy default resolution through a shared resolver used by modules/tabs
- add fallback paths for Waybar and Starship Omarchy defaults
- pin Omarchy-Default to top of pickers with standardized display label
- fix TUI image preview refresh/clear behavior and distortion regressions
- improve apply key handling and expand CLI/TUI test coverage

## Validation
- cargo test --manifest-path rust/Cargo.toml